### PR TITLE
Add @hotwired/turbo >=7.2.0-rc.2 as dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@ This is because CableReady already provides a rich set of powerful [DOM operatio
 
 - [rails](https://rubygems.org/gems/rails) `>=6.1`
 - [turbo-rails](https://rubygems.org/gems/turbo-rails) `>=1.1`
+- [@hotwired/turbo](https://yarnpkg.com/package/@hotwired/turbo) `>=7.2.0-rc.2`
 - [@hotwired/turbo-rails](https://yarnpkg.com/package/@hotwired/turbo-rails) `>=7.2.0-rc.2`
 
 ## Installation


### PR DESCRIPTION
I briefly got stuck finding where`Turbo.StreamActions` is defined.  It looks like you also need to pin to the `@hotwire/turbo` release candidate as well.